### PR TITLE
Bugfix: Product shortcode triggering error when category is empty

### DIFF
--- a/templates/sc-swiper-card-product.php
+++ b/templates/sc-swiper-card-product.php
@@ -38,6 +38,7 @@ function bootscore_product_slider($atts) {
     'orderby' => $orderby,
     'posts_per_page' => $posts,
     'product_cat'    => $category,
+    'post_type' => $type,
   );
 
   $query = new WP_Query($options);


### PR DESCRIPTION
Using the product shortcode with no categories triggers an error because type is not being passed to WP_Query.