### PR TITLE
Improve product template shortcode options 

### DIFF
--- a/templates/sc-swiper-card-product.php
+++ b/templates/sc-swiper-card-product.php
@@ -39,7 +39,7 @@ function bootscore_product_slider($atts) {
     'order'      => 'DESC',
     'orderby'    => 'date',
     'limit'      => 12,
-		'ids'        => '',
+    'ids'        => '',
     'category'   => '',
     'featured'   => '',
     'outofstock' => '',
@@ -54,8 +54,8 @@ function bootscore_product_slider($atts) {
   );
 
   if ($atts['ids']) {
-		$options['post__in'] = array_map('trim', explode(',', sanitize_text_field($atts['ids'])));
-	}
+    $options['post__in'] = array_map('trim', explode(',', sanitize_text_field($atts['ids'])));
+  }
 
   if ($atts['featured'] == 'true') {
     $options['tax_query'][] = array(


### PR DESCRIPTION
If these changes are approved, we can go through the other templates and sync the changes where appropriate, though it may be a couple weeks before we can get to it.

Added: ids attribute to pull in specific products.
Updated: Shortcode to function more like how WooCommerce does
Removed: extract function as it goes against [WordPress Developer Standards](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/#dont-extract)
Bugfix: Default order was set to "order" instead of DESC.
Bugfix: Set limit of 12 for default as currently set to no limit
Security: Contributors and up have access to shortcodes, sanitized attributes to prevent malicious behavior.