### PR TITLE
Revert limit 12 products to posts -1

### DIFF
--- a/templates/sc-swiper-card-product.php
+++ b/templates/sc-swiper-card-product.php
@@ -16,7 +16,7 @@
  * Optional:
  * category="cars, boats"    Will pull products matching these categories    (Default: '')
  * id="1, 2, 3"              Will show products matching these ids           (Default: '')
- * posts="12"                Specify how many products will be shown         (Default: 12)
+ * posts="12"                Specify how many products will be shown         (Default: -1)
  * orderby="date"            Specify how products will be ordered by         (Default: date)
  * order="DESC"              Specify if products will be ordered ASC or DESC (Default: DESC)
  * featured="true"           Will pull featured products                     (Default: false)
@@ -38,8 +38,8 @@ function bootscore_product_slider($atts) {
     'type'       => 'product',
     'order'      => 'DESC',
     'orderby'    => 'date',
-    'posts' => -1,
-    'id'        => '',
+    'posts'      => -1,
+    'id'         => '',
     'category'   => '',
     'featured'   => '',
     'outofstock' => '',

--- a/templates/sc-swiper-card-product.php
+++ b/templates/sc-swiper-card-product.php
@@ -38,7 +38,7 @@ function bootscore_product_slider($atts) {
     'type'       => 'product',
     'order'      => 'DESC',
     'orderby'    => 'date',
-    'limit'      => 12,
+    'posts' => -1,
     'id'        => '',
     'category'   => '',
     'featured'   => '',
@@ -48,7 +48,7 @@ function bootscore_product_slider($atts) {
   $options = array(
     'order'          => sanitize_text_field($atts['order']),
     'orderby'        => sanitize_text_field($atts['orderby']),
-    'posts_per_page' => is_numeric($atts['limit']) ? (int) $atts['limit'] : 12,
+    'posts_per_page' => sanitize_text_field($atts['posts']),
     'product_cat'    => sanitize_text_field($atts['category']),
     'post_type'      => sanitize_text_field($atts['type']),
   );

--- a/templates/sc-swiper-card-product.php
+++ b/templates/sc-swiper-card-product.php
@@ -48,7 +48,7 @@ function bootscore_product_slider($atts) {
   $options = array(
     'order'          => sanitize_text_field($atts['order']),
     'orderby'        => sanitize_text_field($atts['orderby']),
-    'posts_per_page' => sanitize_text_field($atts['posts']),
+    'posts_per_page' => is_numeric($atts['posts']) ? (int) $atts['posts'] : -1,
     'product_cat'    => sanitize_text_field($atts['category']),
     'post_type'      => sanitize_text_field($atts['type']),
   );


### PR DESCRIPTION
I played a bit around with the limit to 12 products.  It was hard to show more than 12 products in the shortcode and I think it is the users job to limit products by himself in the shortcode. In conclusion, I didn't like it. So, this PR reverts the `limit 12` by default  and brings back `post -1`.

@DogByteMarketing  Let me know what you think.

